### PR TITLE
added beautiful cookie banner as banner with api support

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -66,6 +66,7 @@ Categorized, and sorted alphabetically
 - [CookieYes – Cookie Banner for Cookie Consent](https://wordpress.org/plugins/cookie-law-info/).
 - [GDPR Cookie Compliance](https://wordpress.org/plugins/gdpr-cookie-compliance/).
 - [GDPR Cookie Consent Plugin - CCPA Ready](https://www.webtoffee.com/product/gdpr-cookie-consent/).
+- [Beautiful Cookie Consent Banner](https://wordpress.org/plugins/beautiful-and-responsive-cookie-consent/).
 
 = Consent Requiring Plugins =
 - [AddToAny](https://wordpress.org/plugins/add-to-any/).


### PR DESCRIPTION
Hi,

I just implemented the WP consent API to this banner: https://wordpress.org/plugins/beautiful-and-responsive-cookie-consent/
Would be great to have it listed as part of the supporting banners.

Regards
Nikel