### PR TITLE
Update readme.txt to add new integration

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -66,6 +66,7 @@ Categorized, and sorted alphabetically
 - [CookieYes – Cookie Banner for Cookie Consent](https://wordpress.org/plugins/cookie-law-info/).
 - [GDPR Cookie Compliance](https://wordpress.org/plugins/gdpr-cookie-compliance/).
 - [GDPR Cookie Consent Plugin - CCPA Ready](https://www.webtoffee.com/product/gdpr-cookie-consent/).
+- [Pressidium Cookie Consent](https://wordpress.org/plugins/pressidium-cookie-consent/).
 
 = Consent Requiring Plugins =
 - [AddToAny](https://wordpress.org/plugins/add-to-any/).


### PR DESCRIPTION
Hey!

Just a tiny PR to list “Pressidium Cookie Consent” as an existing integration in `readme.txt`.

As a plugin contributor, I can confirm that WP Consent API integration is now part of the latest release.

References
---

* WordPress.org Plugin Directory: https://wordpress.org/plugins/pressidium-cookie-consent/
* GitHub repository: https://github.com/pressidium/pressidium-cookie-consent
* Linking the [integration commit](https://github.com/pressidium/pressidium-cookie-consent/commit/312602fe6137c2a4014b5b4afba599272f4289cf) for reference (in case you need to take a look before merging)

If you need anything else, let me know! 🙂