### PR TITLE
Add Playground PR preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,20 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  preview:
+    name: Post Playground preview button
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Post Playground Preview Button
+        uses: WordPress/action-wp-playground-pr-preview@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          mode: append-to-description
+          plugin-path: .


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that posts a WordPress Playground PR Preview button for pull requests.
- Use the direct `plugin-path: .` setup because WP Consent API can run from the repository checkout with its runtime files already committed.

## Why

This gives contributors and maintainers a quick way to test WP Consent API pull requests in a disposable Playground site from the PR description.

## Testing

- Parsed `.github/workflows/pr-preview.yml` locally as YAML.
- Ran `git diff --cached --check`.
- Ran `composer validate --strict`.
- Ran `vendor/bin/phpstan analyse --memory-limit=1G`.

`composer run lint` currently reports existing PHPCS issues in `inc/class-wp-consent-api-cookie-info.php`; this PR only adds the workflow file and does not change PHP source files.
