### PR TITLE
Add Cookie Consent CMP link to readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,7 @@ Categorized, and sorted alphabetically
 - [Abconsent Sirdata CMP](https://wordpress.org/plugins/sirdata-cmp/).
 - [Beautiful Cookie Consent Banner](https://wordpress.org/plugins/beautiful-and-responsive-cookie-consent/).
 - [Clickio Consent](https://wordpress.org/plugins/clickio-consent/)
+- [Cookie Consent CMP](https://github.com/szepeviktor/cookie-consent-cmp-for-wordpress).
 - [Complianz GDPR/CCPA](https://wordpress.org/plugins/complianz-gdpr/).
 - [Consent Studio](https://consent.studio/).
 - [consentmanager](https://wordpress.org/plugins/consent-manager/).


### PR DESCRIPTION
Hello!

This a dream-come-true for me. A very thin consent manager.

> A lightweight Klaro-based JavaScript consent manager with modular, consent-gated loading for analytics, marketing tags, and embedded media

https://github.com/szepeviktor/cookie-consent-cmp-for-wordpress